### PR TITLE
Fix

### DIFF
--- a/Minimal Lock Screen Theme/Minimal Lock Screen/LockScreenContainerBackground/Image.css
+++ b/Minimal Lock Screen Theme/Minimal Lock Screen/LockScreenContainerBackground/Image.css
@@ -1,6 +1,6 @@
 .lockscreen_Container_3rFFU {
-    background: var(--MLSContainerImage);
-    background-size:cover;
+    background: var(--MLSContainerImage) !important;
+    background-size:cover !important;
 }
 
 /* statusbar background opacity */

--- a/Minimal Lock Screen Theme/Minimal Lock Screen/MLSShared.css
+++ b/Minimal Lock Screen Theme/Minimal Lock Screen/MLSShared.css
@@ -37,7 +37,7 @@
 }
 
 .lockscreen_NumericButtonInput_2wl_h {
-    background-color: var(--MLSBackgroundColor);
+    background-color: var(--MLSBackgroundColor) !important;
     position: absolute;
     bottom: 45px;
     padding: 10px 18px 18px 18px;
@@ -51,7 +51,7 @@
 }
 
 .lockscreen_Indicators_3fJq6 {
-    background-color: var(--MLSBackgroundColor);
+    background-color: var(--MLSBackgroundColor) !important;
     position: absolute;
     bottom: 0;
     right: 0;


### PR DESCRIPTION
Proposed changes prevent system-wide themes (Obsidian, in my case) from overwriting certain aspects of lock screen, such as colour/alpha of background behind lock pad, and background images.