### PR TITLE
Fixes for SteamOS 3.5 in MLS

### DIFF
--- a/Minimal Lock Screen Theme/Minimal Lock Screen/MLSShared.css
+++ b/Minimal Lock Screen Theme/Minimal Lock Screen/MLSShared.css
@@ -39,7 +39,7 @@
 .lockscreen_NumericButtonInput_2wl_h {
     background-color: var(--MLSBackgroundColor) !important;
     position: absolute;
-    bottom: 45px;
+    bottom: 87px;
     padding: 10px 18px 18px 18px;
     border-radius: var(--MLSBorderRadius);
     gap: 0px !important;
@@ -53,7 +53,7 @@
 .lockscreen_Indicators_3fJq6 {
     background-color: var(--MLSBackgroundColor) !important;
     position: absolute;
-    bottom: 0;
+    bottom: 42px;
     right: 0;
 }
 /*


### PR DESCRIPTION
Apparently the layout has changed in a way that bottom:0 is no longer delimited by the command bar, but rather the bottom of the screen itself, so moved everything up 42px.